### PR TITLE
Set http.port=9250

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,8 +1,10 @@
 FROM elasticsearch:2.4
-
+ENV PORT 9250
+EXPOSE "${PORT}"
 RUN ./bin/plugin install analysis-kuromoji
 RUN ./bin/plugin remove analysis-icu
 RUN ./bin/plugin install analysis-icu
 RUN touch ./config/synonym.txt
 RUN touch ./config/userdict_ja.txt
-RUN service elasticsearch restart
+RUN echo "http.port: ${PORT}" > ./config/elasticsearch.yml
+RUN service elasticsearch restart > /dev/null


### PR DESCRIPTION
fablic/elasticsearch:2.0として登録
https://hub.docker.com/r/fablic/elasticsearch/tags/