### PR TITLE
ruby 2.5.5 の dockerfile 作成

### DIFF
--- a/ruby2.5.5/Dockerfile
+++ b/ruby2.5.5/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:2.5.5
+
+RUN apt-get update
+RUN apt-get install -y mysql-server
+RUN curl -J -O -L 'https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7cENtOXlicTFaRUE'
+RUN tar xvzf mecab-0.996.tar.gz
+RUN chmod -R 777 mecab-0.996
+RUN cd mecab-0.996; ./configure --enable-utf8-only --prefix=/usr/local/; make; make install
+RUN ldconfig


### PR DESCRIPTION
ruby 2.5.1 の dockerfile があったのでベースイメージのバージョンを上げただけ