### PR TITLE
fablic/ruby 2.5.5 node

### DIFF
--- a/ruby2.5.5-node/Dockerfile
+++ b/ruby2.5.5-node/Dockerfile
@@ -1,9 +1,9 @@
 FROM circleci/ruby:2.5.5-node
 
-RUN apt-get update
-RUN apt-get install -y mysql-server
-RUN curl -J -O -L 'https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7cENtOXlicTFaRUE'
-RUN tar xvzf mecab-0.996.tar.gz
-RUN chmod -R 777 mecab-0.996
-RUN cd mecab-0.996; ./configure --enable-utf8-only --prefix=/usr/local/; make; make install
-RUN ldconfig
+RUN sudo apt-get update
+RUN sudo apt-get install -y default-mysql-server
+RUN sudo curl -J -O -L 'https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7cENtOXlicTFaRUE'
+RUN sudo tar xvzf mecab-0.996.tar.gz
+RUN sudo chmod -R 777 mecab-0.996
+RUN cd mecab-0.996; ls -l; ./configure --enable-utf8-only --prefix=/usr/local/; sudo make; sudo make install
+RUN sudo ldconfig

--- a/ruby2.5.5-node/Dockerfile
+++ b/ruby2.5.5-node/Dockerfile
@@ -1,9 +1,10 @@
 FROM circleci/ruby:2.5.5-node
 
-RUN sudo apt-get update
-RUN sudo apt-get install -y default-mysql-server
-RUN sudo curl -J -O -L 'https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7cENtOXlicTFaRUE'
-RUN sudo tar xvzf mecab-0.996.tar.gz
-RUN sudo chmod -R 777 mecab-0.996
-RUN cd mecab-0.996; ls -l; ./configure --enable-utf8-only --prefix=/usr/local/; sudo make; sudo make install
-RUN sudo ldconfig
+USER root
+RUN apt-get update
+RUN apt-get install -y default-mysql-server
+RUN curl -J -O -L 'https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7cENtOXlicTFaRUE'
+RUN tar xvzf mecab-0.996.tar.gz
+RUN chmod -R 777 mecab-0.996
+RUN cd mecab-0.996; ls -l; ./configure --enable-utf8-only --prefix=/usr/local/; make; make install
+RUN ldconfig

--- a/ruby2.5.5-node/Dockerfile
+++ b/ruby2.5.5-node/Dockerfile
@@ -1,0 +1,9 @@
+FROM circleci/ruby:2.5.5-node
+
+RUN apt-get update
+RUN apt-get install -y mysql-server
+RUN curl -J -O -L 'https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7cENtOXlicTFaRUE'
+RUN tar xvzf mecab-0.996.tar.gz
+RUN chmod -R 777 mecab-0.996
+RUN cd mecab-0.996; ./configure --enable-utf8-only --prefix=/usr/local/; make; make install
+RUN ldconfig


### PR DESCRIPTION
https://fablic.qiita.com/kanipan20/items/5f32c47af463c0565ce5 に従って動作確認

ビルド
```
$ docker build -t fablic/ruby:2.5.5-node .
```
```
$ docker images | grep node
fablic/ruby                               2.5.5-node           83ebdbb763e6        About a minute ago   1.7GB
```

バージョン確認

```
docker run -it --rm fablic/ruby:2.5.5-node bash

$ ruby -v
ruby 2.5.5p157 (2019-03-15 revision 67260) [x86_64-linux]

$ node -v
v10.16.3

$ yarn -v
1.17.3

$ mecab -v
mecab of 0.996
```