### PR TITLE
add default-mysql-client

### DIFF
--- a/ruby2.5.5-node/Dockerfile
+++ b/ruby2.5.5-node/Dockerfile
@@ -2,6 +2,7 @@ FROM circleci/ruby:2.5.5-node
 
 USER root
 RUN apt-get update
+RUN apt-get install -y default-mysql-client
 RUN apt-get install -y default-mysql-server
 RUN curl -J -O -L 'https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7cENtOXlicTFaRUE'
 RUN tar xvzf mecab-0.996.tar.gz


### PR DESCRIPTION
default-mysql-client が必要だったので追加

```
LoadError: libmariadbclient.so.18: cannot open shared object file
```