### PR TITLE
add image fablic/ruby-2.5.7-mecab

### DIFF
--- a/ruby2.5.7-mecab/Dockerfile
+++ b/ruby2.5.7-mecab/Dockerfile
@@ -1,0 +1,23 @@
+FROM ruby:2.5.7
+
+RUN apt-get update
+RUN apt-get install -y default-mysql-server
+
+WORKDIR /opt
+RUN git clone https://github.com/taku910/mecab.git
+WORKDIR /opt/mecab/mecab
+RUN ./configure  --enable-utf8-only \
+  && make \
+  && make check \
+  && make install \
+  && ldconfig
+
+WORKDIR /opt/mecab/mecab-ipadic
+RUN ./configure --with-charset=utf8 \
+  && make \
+  &&make install
+
+WORKDIR /opt
+RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git
+WORKDIR /opt/mecab-ipadic-neologd
+RUN /opt/mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -n -y

--- a/ruby2.5.7-mecab/Dockerfile
+++ b/ruby2.5.7-mecab/Dockerfile
@@ -7,15 +7,12 @@ WORKDIR /opt
 RUN git clone https://github.com/taku910/mecab.git
 WORKDIR /opt/mecab/mecab
 RUN ./configure  --enable-utf8-only \
-  && make \
-  && make check \
-  && make install \
+  && make all check install \
   && ldconfig
 
 WORKDIR /opt/mecab/mecab-ipadic
 RUN ./configure --with-charset=utf8 \
-  && make \
-  &&make install
+  && make all install
 
 WORKDIR /opt
 RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git


### PR DESCRIPTION
※ブランチ名の2.5.5はミスです。正しくは2.5.7です。

# build

```
docker build -t fablic/ruby:2.5.5-mecab .
Sending build context to Docker daemon   2.56kB
Step 1/13 : FROM ruby:2.5.7
 ---> 1de9aa172c47
Step 2/13 : RUN apt-get update
 ---> Using cache
 ---> db400e17664c
Step 3/13 : RUN apt-get install -y default-mysql-server
 ---> Using cache
 ---> 3362968a54c7
Step 4/13 : WORKDIR /opt
 ---> Using cache
 ---> 22dbfde9f1bd
Step 5/13 : RUN git clone https://github.com/taku910/mecab.git
 ---> Using cache
 ---> 2ae6ff26660d
Step 6/13 : WORKDIR /opt/mecab/mecab
 ---> Using cache
 ---> 6625889b6032
Step 7/13 : RUN ./configure  --enable-utf8-only   && make   && make check   && make install   && ldconfig
 ---> Using cache
 ---> dc18a0491565
Step 8/13 : WORKDIR /opt/mecab/mecab-ipadic
 ---> Using cache
 ---> 358882e0764f
Step 9/13 : RUN ./configure --with-charset=utf8   && make   &&make install
 ---> Using cache
 ---> 80c2785b30fe
Step 10/13 : WORKDIR /opt
 ---> Using cache
 ---> 1b8a2ac8948c
Step 11/13 : RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git
 ---> Using cache
 ---> a95c5c435918
Step 12/13 : WORKDIR /opt/mecab-ipadic-neologd
 ---> Using cache
 ---> 51c6097dc08f
Step 13/13 : RUN /opt/mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -n -y
 ---> Using cache
 ---> 9e2a2473bca6
Successfully built 9e2a2473bca6
Successfully tagged fablic/ruby:2.5.5-mecab
```

# run

```
$ docker run -it --rm fablic/ruby:2.5.5-mecab bash
```

neologdの辞書が使用できて、新語に対応していることを確認

```
root@1f62b6b49a67:/opt/mecab-ipadic-neologd# echo '関ジャム' | mecab -d /usr/local/lib/mecab/dic/mecab-ipadic-neologd
関ジャム	名詞,固有名詞,一般,*,*,*,関ジャム完全燃SHOW,カンジャム,カンジャム
EOS
```

CI上では最初に辞書を最新化する

```
/opt/mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -n -y
```

